### PR TITLE
configure.ac: Bump version to 0.2.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.64)
 
 AC_INIT([dnstap-ldns],
-        [0.2.0],
+        [0.2.1],
         [https://github.com/dnstap/dnstap-ldns/issues],
         [dnstap-ldns],
         [https://github.com/dnstap/dnstap-ldns])


### PR DESCRIPTION
Last release was about six years ago, let's tag a new release containing these fixes: https://github.com/dnstap/dnstap-ldns/milestone/1?closed=1

Thanks!